### PR TITLE
fix: handle comments above github size limit

### DIFF
--- a/src/comment.ts
+++ b/src/comment.ts
@@ -52,14 +52,17 @@ function renderBody(plan: RenderedPlan): string {
 export function renderComment({
   plan,
   header,
-  includeFooter
+  includeFooter,
+  bodyOverride,
 }: {
   plan: RenderedPlan
   header: string
   includeFooter?: boolean
+  bodyOverride?: string
+
 }): string {
-  // Build body
-  const body = renderBody(plan)
+  // Build body if bodyOverride is null
+  const body = bodyOverride ?? renderBody(plan)
 
   // Build footer
   let footer = ''


### PR DESCRIPTION
# Motivation

To support Github's character limit of 65536 characters, optionally display a link to the artefact files in case the plan is too longer to render as a comment.

