### PR TITLE
[PLA-2321] large terraform plan artifacts link is broken

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30176,7 +30176,7 @@ function isValidComment(comment) {
 function getTerraformPlanLink() {
   const { owner, repo } = github2.context.repo;
   const runId = github2.context.runId;
-  return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts`;
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
 }
 async function run() {
   const inputs = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30174,9 +30174,9 @@ function isValidComment(comment) {
   return true;
 }
 function getTerraformPlanLink() {
-  const repo = github2.context.repo;
+  const { owner, repo } = github2.context.repo;
   const runId = github2.context.runId;
-  return `https://github.com/${repo}/actions/runs/${runId}/artifacts`;
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts`;
 }
 async function run() {
   const inputs = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "terraform-pr-comment-action",
+  "name": "terraform-plan-comment",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "terraform-pr-comment-action",
+      "name": "terraform-plan-comment",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,9 @@ function isValidComment(comment: string) {
 
 // Generate link to terraform plan file artifact
 function getTerraformPlanLink() {
-  const repo = github.context.repo
+  const { owner, repo } = github.context.repo
   const runId = github.context.runId
-  return `https://github.com/${repo}/actions/runs/${runId}/artifacts`
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}`
 }
 
 async function run() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function isValidComment(comment: string) {
 function getTerraformPlanLink() {
   const { owner, repo } = github.context.repo
   const runId = github.context.runId
-  return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts`
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}`
 }
 
 async function run() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function isValidComment(comment: string) {
 function getTerraformPlanLink() {
   const { owner, repo } = github.context.repo
   const runId = github.context.runId
-  return `https://github.com/${owner}/${repo}/actions/runs/${runId}`
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts`
 }
 
 async function run() {


### PR DESCRIPTION
# Motivation

when we have a large terraform plan, we see this error and the URL is broken:

<img width="1018" alt="Screenshot 2025-04-22 at 14 11 01" src="https://github.com/user-attachments/assets/935e9b69-dc58-443b-8b79-a4825b3053ea" />


# Changes

`github.context.repo` is an object
